### PR TITLE
Fix to judiweights so that you can do spg on it directly

### DIFF
--- a/src/TimeModeling/judiWeights.jl
+++ b/src/TimeModeling/judiWeights.jl
@@ -82,6 +82,13 @@ adjoint(a::judiWeights{vDT}) where vDT =
 ##########################################################
 
 
+# -(judiWeights)
+function -(a::judiWeights{avDT}) where {avDT}
+    c = deepcopy(a)
+    c.weights = - c.weights
+    return c
+end
+
 # +(judiWeights, judiWeights)
 function +(a::judiWeights{avDT}, b::judiWeights{bvDT}) where {avDT, bvDT}
     size(a) == size(b) || throw(judiWeightsException("dimension mismatch"))
@@ -283,4 +290,14 @@ end
 
 function isapprox(x::judiWeights, y::judiWeights; rtol::Real=sqrt(eps()), atol::Real=0)
     isapprox(x.weights, y.weights; rtol=rtol, atol=atol)
+end
+
+function Base.iterate(x::judiWeights, state=(x.weights[1][1], 1))
+   element, count = state
+
+   if count > x.m
+       return nothing
+   end
+
+   return (element, (x.weights[count ÷ (Int(x.m/x.nsrc)+1) + 1][count % Int(x.m/x.nsrc) + 1], count + 1))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ if GROUP == "JUDI" || GROUP == "All"
         include("test_abstract_vectors.jl")
         include("test_geometry.jl")
         include("test_judiVector.jl")
+        include("test_judiWeights.jl")
         include("test_linear_operators.jl")
     end
 end

--- a/test/test_judiWeights.jl
+++ b/test/test_judiWeights.jl
@@ -1,0 +1,79 @@
+# Unit tests for judiWeights
+# Rafael Orozco (rorozco@gatech.edu)
+# July 2021
+
+using JUDI.TimeModeling, Test, LinearAlgebra
+import LinearAlgebra.BLAS.axpy!
+
+
+# number of sources/receivers
+nsrc = 1
+nrec = 120
+weight_size_x = 4
+weight_size_y = 4
+################################################# test constructors ####################################################
+
+@testset "judiWeights Unit Tests" begin
+
+    # set up judiWeights
+
+
+    # Extended source weights
+    weights = Array{Array}(undef, nsrc)
+    for j=1:nsrc
+        weights[j] = randn(Float32, weight_size_x,weight_size_y) #model size (100,100)
+    end
+    w = judiWeights(weights)
+
+    @test isequal(w.nsrc, nsrc)
+    @test isequal(typeof(w.weights), Array{Array, 1})
+    @test isequal(size(w), (weight_size_x*weight_size_y,1))
+
+
+
+#################################################### test operations ###################################################
+
+    # conj, transpose, adjoint
+    @test isequal(size(w), size(conj(w)))
+
+    @test isequal(reverse(size(w)), size(transpose(w)))
+
+    @test isequal(reverse(size(w)), size(adjoint(w)))
+
+    # +, -, *, /
+    @test iszero(norm(2*w - (w + w)))
+    @test iszero(norm(w - (w + w)/2))
+
+    #test unary operator
+    @test iszero(norm((-w) - (-1*w))) 
+
+    # vcat
+    w_vcat = [w; w]
+    @test isequal(length(w_vcat), 2*length(w))
+    @test isequal(w_vcat.nsrc, 2*w.nsrc)
+
+    # dot, norm, abs
+    @test isapprox(norm(w), sqrt(dot(w, w)))
+    @test isapprox(abs.(w.weights[1]), abs(w).weights[1]) 
+    @test isapprox(abs.(w), vec(vcat(abs(w).weights...))) #this tests the iterator
+
+    # vector space axioms
+    u = judiWeights(randn(Float32, nsrc))
+    v = judiWeights(randn(Float32, nsrc))
+    w = judiWeights(randn(Float32, nsrc))
+    a = randn(1)[1]
+    b = randn(1)[1]
+
+    @test isapprox(u + (v + w), (u + v) + w; rtol=eps(1f0))
+    @test isapprox(u + v, v + u; rtol=eps(1f0))
+    #@test isapprox(u, u + 0; rtol=eps(1f0))
+    @test iszero(norm(u + u*(-1)))
+    @test isapprox(a .* (b .* u), (a * b) .* u; rtol=eps(1f0))
+    @test isapprox(u, u .* 1; rtol=eps(1f0))
+    @test isapprox(a .* (u + v), a .* u + a .* v; rtol=eps(1f0))
+    @test isapprox((a + b) .* v, a .* v + b.* v; rtol=eps(1f0))
+
+    # subsampling #### IMPLEMENT REST OF TESTS LATER
+   
+
+end


### PR DESCRIPTION
Fix to judiweights so that you can do spg on it directly with out the return array hack. 

added the unary operator -judiWeights
and an iterator so that isLegal(judiWeights) works. 

And tests for both. 