### PR TITLE
Add lsrtm objective

### DIFF
--- a/.github/workflows/ci-judi.yml
+++ b/.github/workflows/ci-judi.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        version: ['1.1', '1.2', '1.3', '1.4', '1.5', 'nightly']
+        version: ['1.1', '1.2', '1.3', '1.4', '1.5']
         os: [ubuntu-latest]
         include:
           - version: 1.3

--- a/.github/workflows/ci-op.yml
+++ b/.github/workflows/ci-op.yml
@@ -19,7 +19,7 @@ jobs:
       DEVITO_LANGUAGE: "openmp"
       DEVITO_BACKEND: "core"
       DEVITO_LOGGING: "ERROR"
-      OMP_NUM_THREADS: 2
+      OMP_NUM_THREADS: ${{ matrix.omp }}
       GROUP: ${{ matrix.op }}
 
     strategy:
@@ -29,15 +29,18 @@ jobs:
         os: [ubuntu-latest]
         op: ["ISO_OP", "ISO_OP_FS", "TTI_OP", "TTI_OP_FS"]
         version: ['1.3', '1.4', '1.5']
+        omp: [2]
   
         include:
           - os: macos-latest
             version: '1.4'
             op: "ISO_OP"
+            omp: 1
 
           - os: ubuntu-latest
             version: '1.1'
             op: "ISO_OP_FS"
+            omp: 2
 
 
     steps:

--- a/.github/workflows/ci-op.yml
+++ b/.github/workflows/ci-op.yml
@@ -36,10 +36,6 @@ jobs:
             op: "ISO_OP"
 
           - os: ubuntu-latest
-            version: 'nightly'
-            op: "ISO_OP"
-
-          - os: ubuntu-latest
             version: '1.1'
             op: "ISO_OP_FS"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JUDI"
 uuid = "f3b833dc-6b2e-5b9c-b940-873ed6319979"
 authors = ["Philipp Witte, Mathias Louboutin"]
-version = "2.1.3"
+version = "2.1.4"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/examples/scripts/modeling_basic_2D.jl
+++ b/examples/scripts/modeling_basic_2D.jl
@@ -75,7 +75,7 @@ J = judiJacobian(Pr*F0*adjoint(Ps), q)
 
 # Nonlinear modeling
 dobs = Pr*F*adjoint(Ps)*q
-# Adjoint
+# # Adjoint
 qad = Ps*adjoint(F)*adjoint(Pr)*dobs
 
 # Linearized modeling
@@ -87,7 +87,7 @@ rtm = adjoint(J)*dD
 f, g = fwi_objective(model0, q, dobs; options=opt)
 
 # evaluate LSRTM objective function
-fj, gj = lsrtm_objective(model0, q, dobs, dm; options=opt)
+fj, gj = lsrtm_objective(model0, q, dD, dm; options=opt)
 fjn, gjn = lsrtm_objective(model0, q, dobs, dm; nlind=true, options=opt)
 
 # By extension, lsrtm_objective is the same as fwi_objecive when `dm` is zero

--- a/examples/scripts/modeling_basic_2D.jl
+++ b/examples/scripts/modeling_basic_2D.jl
@@ -85,3 +85,7 @@ rtm = adjoint(J)*dD
 
 # evaluate FWI objective function
 f, g = fwi_objective(model0, q, dobs; options=opt)
+
+# evaluate LSRTM objective function
+fj, gj = lsrtm_objective(model0, q, dobs, dm; options=opt)
+fjn, gjn = lsrtm_objective(model0, q, dobs, dm; nlind=true, options=opt)

--- a/examples/scripts/modeling_basic_2D.jl
+++ b/examples/scripts/modeling_basic_2D.jl
@@ -89,3 +89,10 @@ f, g = fwi_objective(model0, q, dobs; options=opt)
 # evaluate LSRTM objective function
 fj, gj = lsrtm_objective(model0, q, dobs, dm; options=opt)
 fjn, gjn = lsrtm_objective(model0, q, dobs, dm; nlind=true, options=opt)
+
+# By extension, lsrtm_objective is the same as fwi_objecive when `dm` is zero
+# And with computing of the residual. Small noise can be seen in the difference
+# due to floating point roundoff errors with openMP, but running with 
+# OMP_NUM_THREAS=1 (no parllelism) produces the exact (difference == 0) same result
+# gjn2 == g
+fjn2, gjn2 = lsrtm_objective(model0, q, dobs, 0f0.*dm; nlind=true, options=opt)

--- a/examples/scripts/modeling_medical_2D.jl
+++ b/examples/scripts/modeling_medical_2D.jl
@@ -17,8 +17,8 @@ dm = vec(m - m0)
 
 # Setup info and model structure
 nsrc = 1	# number of sources
-model = Model(n, d, o, m)
-model0 = Model(n, d, o, m0)
+model = Model(n, d, o, m, rho)
+model0 = Model(n, d, o, m0, rho)
 
 ## Set up receiver geometry
 nxrec = 120
@@ -56,10 +56,13 @@ info = Info(prod(n), nsrc, ntComp)
 
 ###################################################################################################
 
+opt = Options(isic=true)
 # Setup operators
 Pr = judiProjection(info, recGeometry)
 F = judiModeling(info, model)
+F0 = judiModeling(info, model0; options=opt)
 Ps = judiProjection(info, srcGeometry)
+J = judiJacobian(Pr*F0*adjoint(Ps), q)
 
 # Nonlinear modeling
 dobs = Pr*F*adjoint(Ps)*q
@@ -79,3 +82,5 @@ title("Point source")
 subplot(122)
 imshow(dobs2.data[1], vmin=-a, vmax=a, cmap="seismic", aspect=.25)
 title("Transducer source")
+
+dm = J'*dobs2

--- a/src/Optimization/PQNSlim.jl
+++ b/src/Optimization/PQNSlim.jl
@@ -79,7 +79,7 @@ function  minConf_PQN(funObj,x,funProj,options)
 
     # Output Log
     if options.verbose >= 2
-            @printf("%10s %10s %10s %15s %15s %15s\n","Iteration","FunEvals","Projections","Step Length","Function Val","Opt Cond")
+        @printf("%10s %10s %10s %15s %15s %15s\n","Iteration","FunEvals","Projections","Step Length","Function Val","Opt Cond")
     end
 
     # Make objective function (if using numerical derivatives)

--- a/src/TimeModeling/TimeModeling.jl
+++ b/src/TimeModeling/TimeModeling.jl
@@ -47,6 +47,8 @@ include("extended_source_interface_serial.jl")  # forward/adjoint linear/nonline
 include("extended_source_interface_parallel.jl")    # parallelization for modeling w/ extended source
 include("fwi_objective_serial.jl")  # FWI objective function value and gradient
 include("fwi_objective_parallel.jl")    # parallelization for FWI gradient
+include("lsrtm_objective_serial.jl")  # LSRTM objective function value and gradient
+include("lsrtm_objective_parallel.jl")    # parallelization for LSRTM gradient
 
 #############################################################################
 # Linear operators

--- a/src/TimeModeling/TimeModeling.jl
+++ b/src/TimeModeling/TimeModeling.jl
@@ -20,7 +20,6 @@ import LinearAlgebra.rmul!, LinearAlgebra.mul!, Base.isfinite
 
 import IterativeSolvers.zerox
 
-
 #############################################################################
 # Containers
 include("ModelStructure.jl")    # model container

--- a/src/TimeModeling/auxiliaryFunctions.jl
+++ b/src/TimeModeling/auxiliaryFunctions.jl
@@ -7,7 +7,7 @@
 
 export ricker_wavelet, get_computational_nt, calculate_dt, setup_grid, setup_3D_grid
 export convertToCell, limit_model_to_receiver_area, extend_gradient, remove_out_of_bounds_receivers
-export time_resample, remove_padding, subsample
+export time_resample, remove_padding, subsample, process_input_data
 export generate_distribution, select_frequencies
 export load_pymodel, load_devito_jit, load_numpy, devito_model
 export update_dm, pad_sizes, pad_array
@@ -196,7 +196,7 @@ end
 function extend_gradient(model_full::Modelall,model::Modelall,gradient::Array)
     # Extend gradient back to full model size
     ndim = length(model.n)
-    full_gradient = zeros(Float32,model_full.n)
+    full_gradient = zeros(Float32, model_full.n)
     nx_start = trunc(Int, Float32(Float32(model.o[1] - model_full.o[1])/model.d[1]) + 1)
     nx_end = nx_start + model.n[1] - 1
     if ndim == 2
@@ -373,7 +373,7 @@ function setup_3D_grid(xrec::Array{Any,1},yrec::Array{Any,1},zrec::Array{Any,1})
     # Take input 1d x and y coordinate vectors and generate 3d grid. Input are cell arrays
     nsrc = length(xrec)
     xloc = Array{Any}(undef, nsrc)
-    yloc = Array{Any}(unfef, nsrc)
+    yloc = Array{Any}(undef, nsrc)
     zloc = Array{Any}(undef, nsrc)
     for i=1:nsrc
         nxrec = length(xrec[i])

--- a/src/TimeModeling/fwi_objective_parallel.jl
+++ b/src/TimeModeling/fwi_objective_parallel.jl
@@ -32,12 +32,15 @@ function fwi_objective(model::Modelall, source::judiVector, dObs::judiVector; op
     end
 
     # Collect and reduce gradients
-    gradient = zeros(Float32, prod(model.n) + 1)
+    gradient = zeros(Float32, prod(model.n))
+    objective = 0f0
 
     for j=1:dObs.nsrc
-        gradient += results[j]; results[j] = []
+        gradient .+= results[j][2]
+        objective += results[j][1]
+        results[j] = []
     end
 
     # first value corresponds to function value, the rest to the gradient
-    return gradient[1], gradient[2:end]
+    return objective, gradient
 end

--- a/src/TimeModeling/fwi_objective_serial.jl
+++ b/src/TimeModeling/fwi_objective_serial.jl
@@ -64,5 +64,5 @@ function fwi_objective(model_full::Modelall, source::judiVector, dObs::judiVecto
     if options.limit_m==true
         argout2 = extend_gradient(model_full, model, argout2)
     end
-    return [argout1; vec(argout2)]
+    return argout1, vec(argout2)
 end

--- a/src/TimeModeling/judiComposites.jl
+++ b/src/TimeModeling/judiComposites.jl
@@ -161,11 +161,11 @@ function -(a::judiVStack, b::Number)
 end
 
 function -(a::Number, b::judiVStack)
-    components = Array{Any}(undef, length(a.components))
-    for i=1:length(a.components)
-        components[i] = b .- a.components[i]
+    components = Array{Any}(undef, length(b.components))
+    for i=1:length(b.components)
+        components[i] = a .- b.components[i]
     end
-    return judiVStack{Float32}(a.m, a.n,components)
+    return judiVStack{Float32}(b.m, b.n,components)
 end
 
 function *(a::judiVStack, b::Number)

--- a/src/TimeModeling/judiPDE.jl
+++ b/src/TimeModeling/judiPDE.jl
@@ -242,36 +242,6 @@ end
 ############################################################
 ## overloaded Basees +(...judiPDE...), -(...judiPDE...)
 
-# +(judiPDE,num)
-function +(A::judiPDE{ADDT,ARDT},b::Number) where {ADDT,ARDT}
-    return judiPDE{ADDT,ARDT}("("*A.name*"+N)",A.m,A.n,A.info,A.model,A.geometry,A.options,
-        v1 -> A.fop(v1)+joConstants(A.m,A.n,b;DDT=ADDT,RDT=ARDT)*v1,
-        v2 -> A.fop_T(v2)+joConstants(A.m,A.n,b;DDT=ADDT,RDT=ARDT)*v2
-        )
-end
-
-function +(A::judiPDEadjoint{ADDT,ARDT},b::Number) where {ADDT,ARDT}
-    return judiPDEadjoint{ADDT,ARDT}("("*A.name*"+N)",A.m,A.n,A.info,A.model,A.geometry,A.options,
-        v1->A.fop(v1)+joConstants(A.m,A.n,b;DDT=ADDT,RDT=ARDT)*v1,
-        v2->A.fop_T(v2)+joConstants(A.m,A.n,b;DDT=ADDT,RDT=ARDT)*v2
-        )
-end
-
-# -(judiPDE,num)
-function -(A::judiPDE{ADDT,ARDT},b::Number) where {ADDT,ARDT}
-    return judiPDE{ADDT,ARDT}("("*A.name*"-N)",A.m,A.n,A.info,A.model,A.geometry,A.options,
-        v1 -> A.fop(v1)-joConstants(A.m,A.n,b;DDT=ADDT,RDT=ARDT)*v1,
-        v2 -> A.fop_T(v2)-joConstants(A.m,A.n,b;DDT=ADDT,RDT=ARDT)*v2
-        )
-end
-
-function -(A::judiPDEadjoint{ADDT,ARDT},b::Number) where {ADDT,ARDT}
-    return judiPDEadjoint{ADDT,ARDT}("("*A.name*"-N)",A.m,A.n,A.info,A.model,A.geometry,A.options,
-        v1->A.fop(v1)-joConstants(A.m,A.n,b;DDT=ADDT,RDT=ARDT)*v1,
-        v2->A.fop_T(v2)-joConstants(A.m,A.n,b;DDT=ADDT,RDT=ARDT)*v2
-        )
-end
-
 # -(judiPDE)
 -(A::judiPDE{DDT,RDT}) where {DDT,RDT} =
     judiPDE{DDT,RDT}("(-"*A.name*")",A.m,A.n,A.info,A.model,A.geometry,A.options,

--- a/src/TimeModeling/judiPDEfull.jl
+++ b/src/TimeModeling/judiPDEfull.jl
@@ -123,23 +123,6 @@ end
 
 ############################################################
 ## overloaded Bases +(...judiPDEfull...), -(...judiPDEfull...)
-
-# +(judiPDEfull,num)
-function +(A::judiPDEfull{ADDT,ARDT},b::Number) where {ADDT,ARDT}
-    return judiPDE{ADDT,ARDT}("("*A.name*"+N)",A.m,A.n,A.info,A.model,A.srcGeometry,A.recGeometry,A.options,
-        v1 -> A.fop(v1)+joConstants(A.m,A.n,b;DDT=ADDT,RDT=ARDT)*v1,
-        v2 -> A.fop_T(v2)+joConstants(A.m,A.n,b;DDT=ADDT,RDT=ARDT)*v2
-        )
-end
-
-# -(judiPDEfull,num)
-function -(A::judiPDEfull{ADDT,ARDT},b::Number) where {ADDT,ARDT}
-    return judiPDE{ADDT,ARDT}("("*A.name*"-N)",A.m,A.n,A.info,A.model,A.srcGeometry,A.recGeometry,A.options,
-        v1 -> A.fop(v1)-joConstants(A.m,A.n,b;DDT=ADDT,RDT=ARDT)*v1,
-        v2 -> A.fop_T(v2)-joConstants(A.m,A.n,b;DDT=ADDT,RDT=ARDT)*v2
-        )
-end
-
 # -(judiPDEfull)
 -(A::judiPDEfull{DDT,RDT}) where {DDT,RDT} =
     judiPDEfull{DDT,RDT}("(-"*A.name*")",A.m,A.n,A.info,A.model,A.srcGeometry,A.recGeometry,A.options,

--- a/src/TimeModeling/judiWeights.jl
+++ b/src/TimeModeling/judiWeights.jl
@@ -172,14 +172,14 @@ function *(A::joLinearFunction{ADDT,ARDT},v::judiWeights{avDT}) where {ADDT, ARD
     jo_check_type_match(ADDT,avDT,join(["DDT for *(joLinearFunction,judiWeights):",A.name,typeof(A),avDT]," / "))
     # Evaluate as mat-mat over the weights
     n = size(v.weights[1])
-    V = A.fop(hcat([vec(v.weights[i]) for i=1:v.nsrc]...))
+    V = A.fop(vcat([vec(v.weights[i]) for i=1:v.nsrc]...))
     jo_check_type_match(ARDT,eltype(V),join(["RDT from *(joLinearFunction,judiWeights):",A.name,typeof(A),eltype(V)]," / "))
     m = length(V)
     return judiWeights{avDT}("Extended source weights", m, 1, v.nsrc, [reshape(V[:, i], n) for i=1:length(v.weights)])
 end
 
 # *(joLinearOperator, judiWeights)
-function *(A::joLinearOperator{ADDT,ARDT}, v::judiWeights{avDT}) where {ADDT, ARDT, avDT}
+function *(A::joAbstractLinearOperator{ADDT,ARDT}, v::judiWeights{avDT}) where {ADDT, ARDT, avDT}
     A.n == size(v,1) || throw(judiWeightsException("shape mismatch"))
     jo_check_type_match(ADDT,avDT,join(["DDT for *(joLinearFunction,judiWeights):",A.name,typeof(A),avDT]," / "))
     # Evaluate as mat-mat over the weights
@@ -190,10 +190,9 @@ function *(A::joLinearOperator{ADDT,ARDT}, v::judiWeights{avDT}) where {ADDT, AR
         jo_check_type_match(ARDT,eltype(V),join(["RDT from *(joLinearFunction,judiWeights):",A.name,typeof(A),eltype(V)]," / "))
         return V
     catch e
-        V = A.fop(hcat([vec(v.weights[i]) for i=1:v.nsrc]...))
+        V = A.fop(vcat([vec(v.weights[i]) for i=1:v.nsrc]...))
         jo_check_type_match(ARDT,eltype(V),join(["RDT from *(joLinearFunction,judiWeights):",A.name,typeof(A),eltype(V)]," / "))
-        m = length(V)
-        return judiWeights{avDT}("Extended source weights", m, 1, v.nsrc, [reshape(V[:, i], n) for i=1:v.nsrc])
+        return V
     end
 end
 

--- a/src/TimeModeling/lsrtm_objective_parallel.jl
+++ b/src/TimeModeling/lsrtm_objective_parallel.jl
@@ -33,12 +33,15 @@ function lsrtm_objective(model::Modelall, source::judiVector, dObs::judiVector, 
     end
 
     # Collect and reduce gradients
-    gradient = zeros(Float32, prod(model.n) + 1)
+    gradient = zeros(Float32, prod(model.n))
+    objective = 0f0
 
     for j=1:dObs.nsrc
-        gradient += results[j]; results[j] = []
+        gradient .+= results[j][2]
+        objective += results[j][1]
+        results[j] = []
     end
 
     # first value corresponds to function value, the rest to the gradient
-    return gradient[1], gradient[2:end]
+    return objective, gradient
 end

--- a/src/TimeModeling/lsrtm_objective_parallel.jl
+++ b/src/TimeModeling/lsrtm_objective_parallel.jl
@@ -1,0 +1,44 @@
+# Parallel instance of lsrtm_objective function
+# Author: Mathias Louboutin, mloubutin3@gatech.edu
+# Date: September 202-
+#
+
+"""
+    lsrtm_objective(model, source, dobs, dm; options=Options())
+
+Evaluate the least-square migration objective function. Returns a tuple with function value and vectorized \\
+gradient. `model` is a `Model` structure with the current velocity model and `source` and `dobs` are the wavelets and \\
+observed data of type `judiVector`.
+
+Example
+=======
+
+    function_value, gradient = lsrtm_objective(model, source, dobs, dm)
+
+"""
+function lsrtm_objective(model::Modelall, source::judiVector, dObs::judiVector, dm; options=Options(), nlind=false)
+# lsrtm_objective function for multiple sources. The function distributes the sources and the input data amongst the available workers.
+
+    p = default_worker_pool()
+    lsrtm_objective_par = remote(TimeModeling.lsrtm_objective)
+    lsrtm_objective = retry(lsrtm_objective_par)
+
+    results = Array{Any}(undef, dObs.nsrc)
+
+    @sync begin
+        for j=1:dObs.nsrc
+            opt_local = subsample(options,j)
+            @async results[j] = lsrtm_objective(model, source[j], dObs[j], j, dm; options=opt_local, nlind=nlind)
+        end
+    end
+
+    # Collect and reduce gradients
+    gradient = zeros(Float32, prod(model.n) + 1)
+
+    for j=1:dObs.nsrc
+        gradient += results[j]; results[j] = []
+    end
+
+    # first value corresponds to function value, the rest to the gradient
+    return gradient[1], gradient[2:end]
+end

--- a/src/TimeModeling/lsrtm_objective_serial.jl
+++ b/src/TimeModeling/lsrtm_objective_serial.jl
@@ -46,13 +46,13 @@ function lsrtm_objective(model_full::Modelall, source::judiVector, dObs::judiVec
         argout1, argout2 = pycall(ac."J_adjoint_checkpointing", PyObject, modelPy, src_coords, qIn,
                                   rec_coords, dObserved, is_residual=false, return_obj=true,
                                   t_sub=options.subsampling_factor, space_order=options.space_order,
-                                  born_fwd=true, nlind=nlind)
+                                  born_fwd=true, nlind=nlind, isic=options.isic)
     elseif ~isempty(options.frequencies)
         typeof(options.frequencies) == Array{Any,1} && (options.frequencies = options.frequencies[srcnum])
         argout1, argout2 = pycall(ac."J_adjoint_freq", PyObject, modelPy, src_coords, qIn,
-                                  rec_coords, dObserved, is_residual=false, return_obj=true,
+                                  rec_coords, dObserved, is_residual=false, return_obj=true, nlind=nlind,
                                   freq_list=options.frequencies[1], t_sub=options.subsampling_factor,
-                                  space_order=options.space_order, born_fwd=true, nlind=nlind)
+                                  space_order=options.space_order, born_fwd=true, isic=options.isic)
     else
         argout1, argout2 = pycall(ac."J_adjoint_standard", PyObject, modelPy, src_coords, qIn,
                                   rec_coords, dObserved, is_residual=false, return_obj=true,
@@ -64,5 +64,5 @@ function lsrtm_objective(model_full::Modelall, source::judiVector, dObs::judiVec
         argout2 = extend_gradient(model_full, model, argout2)
     end
 
-    return [argout1; vec(argout2)]
+    return argout1, vec(argout2)
 end

--- a/src/pysource/FD_utils.py
+++ b/src/pysource/FD_utils.py
@@ -1,4 +1,4 @@
-from sympy import sqrt, rot_axis2, rot_axis3
+from sympy import rot_axis2, rot_axis3
 
 from devito import TensorFunction, VectorFunction, Eq, Differentiable
 
@@ -78,7 +78,12 @@ def R_mat(model):
         Rt *= rot_axis3(model.phi)
     else:
         Rt = Rt[[0, 2], [0, 2]]
-    return TensorFunction(name="R", grid=model.grid, components=Rt, symmetric=False)
+    R = TensorFunction(name="R", grid=model.grid, components=Rt, symmetric=False)
+    try:
+        R.name == "R"
+        return R
+    except AttributeError:
+        return Rt
 
 
 def P_M(model, u, v):
@@ -117,8 +122,8 @@ def thomsen_mat(model):
     a_ii = [[b * delt, 0, 0],
             [0, b * delt, 0],
             [0, 0, b]]
-    b_ii = [[b * sqrt((eps - delt) * delt), 0, 0],
-            [0, b * sqrt((eps - delt) * delt), 0],
+    b_ii = [[b * ((eps - delt) * delt)**.5, 0, 0],
+            [0, b * ((eps - delt) * delt)**.5, 0],
             [0, 0, 0]]
     c_ii = [[b * (eps - delt), 0, 0],
             [0, b * (eps - delt), 0],

--- a/src/pysource/interface.py
+++ b/src/pysource/interface.py
@@ -420,9 +420,8 @@ def grad_fwi(model, recin, rec_coords, u, space_order=8):
 
 
 def J_adjoint(model, src_coords, wavelet, rec_coords, recin, space_order=8,
-              checkpointing=False, n_checkpoints=None,
-              maxmem=None, freq_list=[], dft_sub=None, isic=False, ws=None,
-              t_sub=1):
+              checkpointing=False, n_checkpoints=None, t_sub=1,
+              maxmem=None, freq_list=[], dft_sub=None, isic=False, ws=None):
     """
     Jacobian (adjoint fo born modeling operator) operator on a shot record
     as a source (i.e data residual). Supports three modes:
@@ -514,6 +513,11 @@ def J_adjoint_freq(model, src_coords, wavelet, rec_coords, recin, space_order=8,
         Extended source spatial distribution
     is_residual: Bool
         Whether to treat the input as the residual or as the observed data
+    born_fwd: Bool
+        Whether to use the forward or linearized forward modeling operator
+    nlind: Bool
+        Whether to remove the non linear data from the input data. This option is
+        only available in combination with `born_fwd`
 
     Returns
     ----------
@@ -565,6 +569,11 @@ def J_adjoint_standard(model, src_coords, wavelet, rec_coords, recin, space_orde
         Extended source spatial distribution
     is_residual: Bool
         Whether to treat the input as the residual or as the observed data
+    born_fwd: Bool
+        Whether to use the forward or linearized forward modeling operator
+    nlind: Bool
+        Whether to remove the non linear data from the input data. This option is
+        only available in combination with `born_fwd`
 
     Returns
     ----------
@@ -621,6 +630,11 @@ def J_adjoint_checkpointing(model, src_coords, wavelet, rec_coords, recin, space
         Extended source spatial distribution
     is_residual: Bool
         Whether to treat the input as the residual or as the observed data
+    born_fwd: Bool
+        Whether to use the forward or linearized forward modeling operator
+    nlind: Bool
+        Whether to remove the non linear data from the input data. This option is
+        only available in combination with `born_fwd`
 
     Returns
     ----------

--- a/src/pysource/interface.py
+++ b/src/pysource/interface.py
@@ -483,8 +483,8 @@ def J_adjoint(model, src_coords, wavelet, rec_coords, recin, space_order=8,
 
 
 def J_adjoint_freq(model, src_coords, wavelet, rec_coords, recin, space_order=8,
-                   freq_list=[], is_residual=False, return_obj=False,
-                   dft_sub=None, isic=False, ws=None, t_sub=1):
+                   freq_list=[], is_residual=False, return_obj=False, nlind=False,
+                   dft_sub=None, isic=False, ws=None, t_sub=1, born_fwd=False):
     """
     Jacobian (adjoint fo born modeling operator) operator on a shot record
     as a source (i.e data residual). Outputs the gradient with Frequency
@@ -520,11 +520,15 @@ def J_adjoint_freq(model, src_coords, wavelet, rec_coords, recin, space_order=8,
     Array
         Adjoint jacobian on the input data (gradient)
     """
-    rec, u, _ = forward(model, src_coords, rec_coords, wavelet, save=False, ws=ws,
-                        space_order=space_order, freq_list=freq_list, dft_sub=dft_sub)
+    rec, u, _ = op_fwd_J[born_fwd](model, src_coords, rec_coords, wavelet, save=False,
+                                   space_order=space_order, freq_list=freq_list,
+                                   ws=ws, dft_sub=dft_sub, nlind=nlind)
     # Residual and gradient
     if not is_residual:
-        recin[:] = rec.data[:] - recin[:]   # input is observed data
+        if nlind:
+            recin[:] = rec[0].data[:] - (recin[:] - rec[1].data)  # input is observed data
+        else:
+            recin[:] = rec.data[:] - recin[:]   # input is observed data
 
     g, _ = gradient(model, recin, rec_coords, u, space_order=space_order, isic=isic,
                     freq=freq_list, dft_sub=dft_sub)
@@ -534,8 +538,8 @@ def J_adjoint_freq(model, src_coords, wavelet, rec_coords, recin, space_order=8,
 
 
 def J_adjoint_standard(model, src_coords, wavelet, rec_coords, recin, space_order=8,
-                       is_residual=False, return_obj=False,
-                       isic=False, ws=None, t_sub=1):
+                       is_residual=False, return_obj=False, born_fwd=False,
+                       isic=False, ws=None, t_sub=1, nlind=False):
     """
     Adjoint Jacobian (adjoint fo born modeling operator) operator on a shot record
     as a source (i.e data residual). Outputs the gradient with standard
@@ -567,11 +571,15 @@ def J_adjoint_standard(model, src_coords, wavelet, rec_coords, recin, space_orde
     Array
         Adjoint jacobian on the input data (gradient)
     """
-    rec, u, _ = forward(model, src_coords, rec_coords, wavelet, save=True, ws=ws,
-                        space_order=space_order, t_sub=t_sub)
+    rec, u, _ = op_fwd_J[born_fwd](model, src_coords, rec_coords, wavelet, save=True,
+                                   ws=ws, space_order=space_order,
+                                   t_sub=t_sub, nlind=nlind)
     # Residual and gradient
     if not is_residual:
-        recin[:] = rec.data[:] - recin[:]   # input is observed data
+        if nlind:
+            recin[:] = rec[0].data[:] - (recin[:] - rec[1].data)  # input is observed data
+        else:
+            recin[:] = rec.data[:] - recin[:]   # input is observed data
 
     g, _ = gradient(model, recin, rec_coords, u, space_order=space_order, isic=isic)
     if return_obj:
@@ -580,9 +588,9 @@ def J_adjoint_standard(model, src_coords, wavelet, rec_coords, recin, space_orde
 
 
 def J_adjoint_checkpointing(model, src_coords, wavelet, rec_coords, recin, space_order=8,
-                            is_residual=False, n_checkpoints=None,
+                            is_residual=False, n_checkpoints=None, born_fwd=False,
                             maxmem=None, return_obj=False, isic=False, ws=None,
-                            t_sub=1):
+                            t_sub=1, nlind=False):
     """
     Jacobian (adjoint fo born modeling operator) operator on a shot record
     as a source (i.e data residual). Outputs the gradient with Checkpointing.
@@ -620,8 +628,9 @@ def J_adjoint_checkpointing(model, src_coords, wavelet, rec_coords, recin, space
         Adjoint jacobian on the input data (gradient)
     """
     # Optimal checkpointing
-    op_f, u, rec_g = forward(model, src_coords, rec_coords, wavelet,
-                             space_order=space_order, return_op=True, ws=ws)
+    op_f, u, rec_g = op_fwd_J[born_fwd](model, src_coords, rec_coords, wavelet,
+                                        space_order=space_order, return_op=True,
+                                        nlind=nlind, ws=ws)
     op, g, v = gradient(model, recin, rec_coords, u, space_order=space_order,
                         return_op=True, isic=isic)
 
@@ -634,7 +643,7 @@ def J_adjoint_checkpointing(model, src_coords, wavelet, rec_coords, recin, space
     # Op arguments
     uk = {uu.name: uu for uu in as_tuple(u)}
     vk = {**uk, **{vv.name: vv for vv in as_tuple(v)}}
-    uk.update({'rcv%s' % as_tuple(u)[0].name: rec_g})
+    uk.update({'rcv%s' % as_tuple(u)[0].name: as_tuple(rec_g)[0]})
     vk.update({'src%s' % as_tuple(v)[0].name: rec})
     # Wrapped ops
     wrap_fw = CheckpointOperator(op_f, vp=model.vp, **uk)
@@ -648,10 +657,17 @@ def J_adjoint_checkpointing(model, src_coords, wavelet, rec_coords, recin, space
     if is_residual is True:  # input data is already the residual
         rec.data[:] = recin[:]
     else:
-        rec.data[:] = rec.data[:] - recin[:]   # input is observed data
+        # This won't work with MPI
+        if nlind:
+            rec.data[:] = rec_g[0].data[:] - (recin[:] - rec_g[1].data)
+        else:
+            rec.data[:] = rec_g.data[:] - recin[:]
 
     wrp.apply_reverse()
 
     if return_obj:
         return .5*model.critical_dt*norm(rec)**2, g.data
     return g.data
+
+
+op_fwd_J = {False: forward, True: born}

--- a/src/pysource/kernels.py
+++ b/src/pysource/kernels.py
@@ -38,7 +38,6 @@ def wave_kernel(model, u, fw=True, q=None):
     else:
         pde = acoustic_kernel(model, u, fw, q=q)
         fact = []
-
     pde += freesurface(model, pde) if model.fs else []
     return pde, fact
 

--- a/src/pysource/models.py
+++ b/src/pysource/models.py
@@ -143,7 +143,7 @@ class GenericModel(object):
         """
         if field is None:
             return func(default_value)
-        if isinstance(field, np.ndarray):
+        if isinstance(field, np.ndarray) and (np.min(field) != np.max(field)):
             function = Function(name=name, grid=self.grid, space_order=space_order,
                                 parameter=is_param)
             if field.shape == self.shape:
@@ -151,7 +151,7 @@ class GenericModel(object):
             else:
                 function._data_with_outhalo[:] = func(field)
         else:
-            return func(field)
+            return func(np.min(field))
         self._physical_parameters.append(name)
         return function
 

--- a/src/pysource/models.py
+++ b/src/pysource/models.py
@@ -64,7 +64,7 @@ def initialize_damp(damp, padsizes, spacing, fs=False):
     """
     lqmin = np.log(.1)
     lqmax = np.log(100)
-    w0 = 1/(10 * np.mean(spacing))
+    w0 = 1/(10 * np.max(spacing))
 
     z = damp.dimensions[-1]
     eqs = [Eq(damp, 1)]

--- a/src/pysource/propagators.py
+++ b/src/pysource/propagators.py
@@ -105,8 +105,7 @@ def gradient(model, residual, rcv_coords, u, return_op=False, space_order=8,
              w=None, freq=None, dft_sub=None, isic=False):
     """
     Low level propagator, to be used through `interface.py`
-    Compute adjoint wavefield v = adjoint(F(m))*y
-    and related quantities (||v||_w, v(xsrc))
+    Compute the action of the adjoint Jacobian onto a residual J'* δ d.
     """
     # Setting adjoint wavefieldgradient
     v = wavefield(model, space_order, fw=False)
@@ -141,8 +140,8 @@ def born(model, src_coords, rcv_coords, wavelet, space_order=8, save=False,
          ws=None, t_sub=1, nlind=False):
     """
     Low level propagator, to be used through `interface.py`
-    Compute adjoint wavefield v = adjoint(F(m))*y
-    and related quantities (||v||_w, v(xsrc))
+    Compute linearized wavefield U = J(m)* δ m
+    and related quantities.
     """
     nt = wavelet.shape[0]
     # Setting wavefield
@@ -159,6 +158,9 @@ def born(model, src_coords, rcv_coords, wavelet, space_order=8, save=False,
     # Set up PDE expression and rearrange
     pde, tmpu = wave_kernel(model, u, q=q)
     pdel, tmpul = wave_kernel(model, ul, q=lin_src(model, u, isic=isic))
+    if model.dm == 0:
+        print("hello")
+        pdel, tmpul = [], []
 
     # Setup source and receiver
     geom_expr, _, rcvnl = src_rec(model, u, rec_coords=rcv_coords if nlind else None,
@@ -177,6 +179,7 @@ def born(model, src_coords, rcv_coords, wavelet, space_order=8, save=False,
     outrec = (rcvl, rcvnl) if nlind else rcvl
     if return_op:
         return op, u, outrec
+
     summary = op()
 
     # Output

--- a/src/pysource/propagators.py
+++ b/src/pysource/propagators.py
@@ -159,7 +159,6 @@ def born(model, src_coords, rcv_coords, wavelet, space_order=8, save=False,
     pde, tmpu = wave_kernel(model, u, q=q)
     pdel, tmpul = wave_kernel(model, ul, q=lin_src(model, u, isic=isic))
     if model.dm == 0:
-        print("hello")
         pdel, tmpul = [], []
 
     # Setup source and receiver

--- a/src/pysource/wave_utils.py
+++ b/src/pysource/wave_utils.py
@@ -174,10 +174,11 @@ def freesurface(model, eq):
             for f in funcs:
                 zind = f.indices[-1]
                 if (zind - z).as_coeff_Mul()[0] < 0:
-                    s = sign(zind.subs({z: zfs, z.spacing: 1}))
+                    s = sign((zind - z.symbolic_min).subs({z: zfs, z.spacing: 1}))
                     mapper.update({f: s * f.subs({zind: INT(abs(zind))})})
             fs_eq.append(Eq(lhs, rhs.subs(mapper),
                             subdomain=model.grid.subdomains['fsdomain']))
+
     return fs_eq
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,45 +16,51 @@ if endswith(GROUP, ".jl")
     include(GROUP)
 end
 
+base = ["test_abstract_vectors.jl",
+        "test_geometry.jl",
+        "test_judiVector.jl",
+        "test_composite.jl",
+        "test_judiWeights.jl",
+        "test_judiWavefield.jl",
+        "test_linear_operators.jl"]
+
+devito = ["test_linearity.jl",
+          "test_jacobian.jl",
+          "test_jacobian_extended.jl",
+          "test_adjoint.jl",
+          "test_gradient_fwi.jl",
+          "test_gradient_lsrtm.jl",
+          "test_all_options.jl"]
+
+extras = ["test_basics.jl", "test_linear_algebra.jl"]
+
 # Basic JUDI objects tests, no Devito
 if GROUP == "JUDI" || GROUP == "All"
-    include("test_abstract_vectors.jl")
-    include("test_geometry.jl")
-    include("test_judiVector.jl")
-    include("test_composite.jl")
-    include("test_judiWeights.jl")
-    include("test_judiWavefield.jl")
-    include("test_linear_operators.jl")
+    for t=base
+        include(t)
+    end
 end
 
 # Isotropic Acoustic tests
 if GROUP == "ISO_OP" || GROUP == "All"
     println("JUDI iso-acoustic operators tests (parallel)")
-    # Basic utility test
-    include("test_basics.jl")
+    for t=extras
+        include(t)
+    end
     # Basic test of LA/CG/LSQR needs
     push!(Base.ARGS, "-p 2")
-    include("test_linear_algebra.jl")
-    # Iso-acoustic tests
-    include("test_modeling.jl")
-    include("test_linearity.jl")
-    include("test_jacobian.jl")
-    include("test_jacobian_extended.jl")
-    include("test_adjoint.jl")
-    include("test_gradient_fwi.jl")
-    include("test_all_options.jl")
+    for t=devito
+        include(t)
+    end
 end
 
 # Isotropic Acoustic tests with a free surface
 if GROUP == "ISO_OP_FS" || GROUP == "All"
     println("JUDI iso-acoustic operators with free surface tests")
     push!(Base.ARGS, "--fs")
-    include("test_linearity.jl")
-    include("test_jacobian.jl")
-    include("test_jacobian_extended.jl")
-    include("test_adjoint.jl")
-    include("test_gradient_fwi.jl")
-    include("test_all_options.jl")
+    for t=devito
+        include(t)
+    end
 end
 
 # Anisotropic Acoustic tests
@@ -62,12 +68,9 @@ if GROUP == "TTI_OP" || GROUP == "All"
     println("JUDI TTI operators tests")
     # TTI tests
     push!(Base.ARGS, "--tti")
-    include("test_linearity.jl")
-    include("test_jacobian.jl")
-    include("test_jacobian_extended.jl")
-    include("test_adjoint.jl")
-    include("test_gradient_fwi.jl")
-    include("test_all_options.jl")
+    for t=devito
+        include(t)
+    end
 end
 
 # Anisotropic Acoustic tests with free surface
@@ -75,10 +78,7 @@ if GROUP == "TTI_OP_FS" || GROUP == "All"
     println("JUDI TTI operators with free surfacetests")
     push!(Base.ARGS, "--tti")
     push!(Base.ARGS, "--fs")
-    include("test_linearity.jl")
-    include("test_jacobian.jl")
-    include("test_jacobian_extended.jl")
-    include("test_adjoint.jl")
-    include("test_gradient_fwi.jl")
-    include("test_all_options.jl")
+    for t=devito
+        include(t)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,8 +29,8 @@ devito = ["test_linearity.jl",
           "test_jacobian_extended.jl",
           "test_adjoint.jl",
           "test_gradient_fwi.jl",
-          "test_gradient_lsrtm.jl",
-          "test_all_options.jl"]
+          "test_all_options.jl",
+          "test_gradient_lsrtm.jl"]
 
 extras = ["test_basics.jl", "test_linear_algebra.jl"]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,7 +32,7 @@ devito = ["test_linearity.jl",
           "test_all_options.jl",
           "test_gradient_lsrtm.jl"]
 
-extras = ["test_basics.jl", "test_linear_algebra.jl"]
+extras = ["test_modeling.jl", "test_basics.jl", "test_linear_algebra.jl"]
 
 # Basic JUDI objects tests, no Devito
 if GROUP == "JUDI" || GROUP == "All"

--- a/test/test_abstract_vectors.jl
+++ b/test/test_abstract_vectors.jl
@@ -18,10 +18,20 @@ using JUDI.TimeModeling, SegyIO, Test, LinearAlgebra
     for j=1:nsrc
         data[j] = randn(Float32, rec_geometry.nt[j], length(rec_geometry.xloc[j]))
     end
+    datacell = process_input_data(vec(hcat(data...)), rec_geometry, info)
+    @test isequal(datacell, data)
+
     rhs = judiRHS(info, rec_geometry, data)
+    Pr = judiProjection(info, rec_geometry)
 
     @test isequal(typeof(rhs), judiRHS{Float32})
     @test isequal(rhs.geometry, rec_geometry)
+
+    rhs2 = Pr'*vec(hcat(data...))
+    @test isequal(typeof(rhs2), judiRHS{Float32})
+    @test isequal(rhs2.geometry, rec_geometry)
+    @test isequal(rhs2.geometry, rhs.geometry)
+    @test isequal(rhs2.data, rhs.data)
 
     # conj, transpose, adjoint
     @test isequal(size(rhs), size(conj(rhs)))

--- a/test/test_adjoint.jl
+++ b/test/test_adjoint.jl
@@ -9,13 +9,13 @@ parsed_args = parse_commandline()
 
 
 nlayer = parsed_args["nlayer"]
-tti = parsed_args["fs"]
+tti = parsed_args["tti"]
 fs =  parsed_args["fs"]
 
 # Set parallel if specified
 nw = parsed_args["parallel"]
 if nw > 1 && nworkers() < nw
-    addprocs(nw-nworkers() + 1; exeflags=`--check-bounds=yes`)
+    addprocs(nw-nworkers() + 1; exeflags=["--code-coverage=user", "--inline=no", "--check-bounds=yes"])
 end
 
 @everywhere using JUDI.TimeModeling, LinearAlgebra, Test, Distributed, Printf

--- a/test/test_all_options.jl
+++ b/test/test_all_options.jl
@@ -6,7 +6,7 @@ using PyCall, PyPlot, JUDI.TimeModeling, Images, LinearAlgebra, Test, ArgParse, 
 parsed_args = parse_commandline()
 
 nlayer = parsed_args["nlayer"]
-tti = parsed_args["fs"]
+tti = parsed_args["tti"]
 fs =  parsed_args["fs"]
 
 ### Model

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -73,7 +73,33 @@ function test_limit_m(ndim, tti)
 
 end
 
+function setup_3d()
+    xrec = Array{Any}(undef, 2)
+    yrec = Array{Any}(undef, 2)
+    zrec = Array{Any}(undef, 2)
+    for i=1:2
+        xrec[i] = i .+ collect(0:10)
+        yrec[i] = i .+ collect(0:10)
+        zrec[i] = i
+    end
+    x3d, y3d, z3d = setup_3D_grid(xrec[1],yrec[1],zrec[1])
+    for k=1:11
+        @test all(y3d[(11*(k-1))+1:(11*(k-1))+11] .== k)
+        @test all(x3d[k:11:end] .== k)
+    end
+    @test all(z3d[:] .== 1)
+    x3d, y3d, z3d = setup_3D_grid(xrec,yrec,zrec)
+    for i=1:2
+        for k=1:11
+            @test all(y3d[i][(11*(k-1))+1:(11*(k-1))+11] .== k + i -1)
+            @test all(x3d[i][k:11:end] .== k + i - 1)
+        end
+        @test all(z3d[i][:] .== i)
+    end
+end
+
 @testset "Test basic utilities" begin
+    setup_3d()
     for ndim=[2, 3]
         test_padding(ndim)
     end

--- a/test/test_composite.jl
+++ b/test/test_composite.jl
@@ -34,6 +34,8 @@ ftol = 1f-6
     c2 = [w0; d_obs]
     c2_b = deepcopy(c2)
 
+    @test firstindex(c1) == 1
+    @test lastindex(c1) == 2
     @test isapprox(length(c1), length(d_obs) + length(w0))
     @test eltype(c1) == Float32
     @test isfinite(c1)
@@ -99,6 +101,9 @@ ftol = 1f-6
     @test isapprox(norm(u_scale, 2), sqrt(dot(u_scale, u_scale)); rtol=1f-6)
     @test isapprox(norm(u_scale, 1), norm(d_obs, 1) + norm(w0, 1))
     @test isapprox(norm(u_scale, Inf), max(norm(d_obs, Inf), norm(w0, Inf)))
+    @test isapprox(norm(u_scale - 1f0, 1), norm(u_scale .- 1f0, 1))
+    @test isapprox(norm(1f0 - u_scale, 1), norm(1f0 .- u_scale, 1))
+    @test isapprox(norm(u_scale/2f0, 1), norm(u_scale, 1)/2f0)
 # Test broadcasting
     u_scale = deepcopy(u)
     v_scale = deepcopy(v)

--- a/test/test_gradient_fwi.jl
+++ b/test/test_gradient_fwi.jl
@@ -12,7 +12,7 @@ parsed_args = parse_commandline()
 
 
 nlayer = parsed_args["nlayer"]
-tti = parsed_args["fs"]
+tti = parsed_args["tti"]
 fs =  parsed_args["fs"]
 
 ### Model

--- a/test/test_gradient_lsrtm.jl
+++ b/test/test_gradient_lsrtm.jl
@@ -1,0 +1,87 @@
+# 2D FWI gradient test with 4 sources
+# The receiver positions and the source wavelets are the same for each of the four experiments.
+# Author: Philipp Witte, pwitte@eos.ubc.ca
+# Date: January 2017
+#
+# Mathias Louboutin, mlouboutin3@gatech.edu
+# Updated July 2020
+
+using JUDI.TimeModeling, Test, LinearAlgebra, PyPlot, Printf
+
+parsed_args = parse_commandline()
+
+nlayer = parsed_args["nlayer"]
+tti = parsed_args["fs"]
+fs =  parsed_args["fs"]
+
+### Model
+model, model0, dm = setup_model(parsed_args["tti"], 4)
+q, srcGeometry, recGeometry, info = setup_geom(model)
+dt = srcGeometry.dt[1]
+
+###################################################################################################
+
+@testset "LSRTM gradient test with $(nlayer) layers and tti $(tti) and freesurface $(fs)" begin
+	# Gradient test
+	h = 5f-2
+	maxiter = 6
+	err1 = zeros(maxiter, 2)
+	err2 = zeros(maxiter, 2)
+	h_all = zeros(maxiter, 2)
+
+	# Observed data
+	opt = Options(sum_padding=false, free_surface=parsed_args["fs"])
+	F = judiModeling(info, model, srcGeometry, recGeometry; options=opt)
+	d = F*q
+
+	# FWI gradient and function value for m0
+	Jm0, grad = lsrtm_objective(model0, q, d, dm; options=opt)
+	Jm01, grad1 = lsrtm_objective(model0, q, d, dm; options=opt, nlind=true)
+
+	dJ = dot(grad, vec(dm))
+	dJ1 = dot(grad1, vec(dm))
+	dm_pert = randn(size(dm)) .* dm
+
+	for j=1:maxiter
+		# FWI gradient and function falue for m0 + h*dm
+		dmloc = dm + h*dm_pert
+		Jm, _ = lsrtm_objective(model0, q, d, dmloc; options=opt)
+		Jm1, _ = lsrtm_objective(model0, q, d, dmloc; options=opt, nlind=true)
+
+		# Check convergence
+		err1[j, 1] = abs(Jm - Jm0)
+		err1[j, 2] = abs(Jm1 - Jm01)
+		err2[j, 1] = abs(Jm - (Jm0 + h*dJ))
+		err2[j, 2] = abs(Jm1 - (Jm01 + h*dJ1))
+
+		j == 1 ? prev = 1 : prev = j - 1
+		for i=1:2
+			@printf("h = %2.2e, e1 = %2.2e, rate = %2.2e", h, err1[j, i], err1[prev, i]/err1[j, i])
+			@printf(", e2  = %2.2e, rate = %2.2e \n", err2[j, i], err2[prev, i]/err2[j, i])
+		end
+		h_all[j] = h
+		h = h * .8f0
+	end
+
+	for i=1:2
+		# CHeck convergence rates
+		rate_1 = sum(err1[1:end-1, i]./err1[2:end, i])/(maxiter - 1)
+		rate_2 = sum(err2[1:end-1, i]./err2[2:end, i])/(maxiter - 1)
+
+		# This is a linearized problem, so the whole expansiaon is O(dm) and
+		# "second order error" should be first order
+		@test isapprox(rate_1, 1.25f0; rtol=5f-2)
+		@test isapprox(rate_2, 1.25f0; rtol=5f-2)
+	end
+
+	# Plot errors
+	if isinteractive()
+		loglog(h_all, err1); loglog(h_all, h_all/h_all[1]*err1[1])
+		loglog(h_all, err2); loglog(h_all, ( h_all/h_all[1]).^2 * err2[1])
+		legend([L"$\Phi(m) - \Phi(m0)$", "1st order", L"$\Phi(m) - \Phi(m0) - \nabla \Phi \delta m$", "2nd order"], loc="lower right")
+		xlabel("h")
+		ylabel(L"Error $||\cdot||^\infty$")
+		title("FWI gradient test")
+		
+	end
+end

--- a/test/test_gradient_lsrtm.jl
+++ b/test/test_gradient_lsrtm.jl
@@ -11,7 +11,7 @@ using JUDI.TimeModeling, Test, LinearAlgebra, PyPlot, Printf
 parsed_args = parse_commandline()
 
 nlayer = parsed_args["nlayer"]
-tti = parsed_args["fs"]
+tti = parsed_args["tti"]
 fs =  parsed_args["fs"]
 
 ### Model

--- a/test/test_jacobian.jl
+++ b/test/test_jacobian.jl
@@ -11,7 +11,7 @@ using JUDI.TimeModeling, SegyIO, LinearAlgebra, Test, Printf
 parsed_args = parse_commandline()
 
 nlayer = parsed_args["nlayer"]
-tti = parsed_args["fs"]
+tti = parsed_args["tti"]
 fs =  parsed_args["fs"]
 
 ### Model

--- a/test/test_jacobian_extended.jl
+++ b/test/test_jacobian_extended.jl
@@ -11,7 +11,7 @@ using JUDI.TimeModeling, SegyIO, LinearAlgebra, Test
 parsed_args = parse_commandline()
 
 nlayer = parsed_args["nlayer"]
-tti = parsed_args["fs"]
+tti = parsed_args["tti"]
 fs =  parsed_args["fs"]
 
 ### Model

--- a/test/test_judiVector.jl
+++ b/test/test_judiVector.jl
@@ -27,10 +27,12 @@ ftol = 1e-6
 @testset "judiVector Unit Tests with $(nsrc) sources" for nsrc=[1, 2]
 
     # set up judiVector fr,om array
+    info = example_info(nsrc=nsrc)
     dsize = (nsrc*nrec*ns, 1)
     rec_geometry = example_rec_geometry(nsrc=nsrc, nrec=nrec)
     data = randn(Float32, ns, nrec)
     d_obs = judiVector(rec_geometry, data)
+    @test isequal(process_input_data(d_obs, rec_geometry, info), d_obs.data)
 
     @test isequal(d_obs.nsrc, nsrc)
     @test isequal(typeof(d_obs.data), Array{Array, 1})

--- a/test/test_judiWeights.jl
+++ b/test/test_judiWeights.jl
@@ -33,6 +33,20 @@ ftol = 1f-6
     @test isequal(typeof(w.weights), Array{Array, 1})
     @test isequal(size(w), (weight_size_x*weight_size_y*nsrc, 1))
     @test isfinite(w)
+
+    I2 = ones(Float32, 1, size(w, 1))
+    w2 = I2*w
+    @test isapprox(w2[1], sum(sum(w.weights)))
+
+    I2 = joOnes(1, size(w, 1); DDT=Float32, RDT=Float32)
+    w2 = I2*w
+    @test isapprox(w2[1], sum(sum(w.weights)))
+
+    I3 = [I2;I2]
+    w3 = I3*w
+    @test isapprox(w3[1], sum(sum(w.weights)))
+    @test isapprox(w3[2], sum(sum(w.weights)))
+
 #################################################### test operations ###################################################
     # Indexing/reshape/...
     @test isapprox(w[1].weights[1], w.weights[1])
@@ -49,6 +63,28 @@ ftol = 1f-6
 
     #test unary operator
     @test iszero(norm((-w) - (-1*w))) 
+
+    # Copies and iter utilities
+    w2 = copy(w)
+    @test isequal(w2.weights, w.weights)
+    @test isequal(w2.nsrc, w.nsrc)
+    @test firstindex(w) == 1
+    @test lastindex(w) == nsrc
+    @test ndims(w) == 2
+
+    w2 = similar(w, Float32, 1:2)
+    @test isequal(w2.weights, 0f0.* w.weights)
+    @test isequal(w2.nsrc, w.nsrc)
+    @test firstindex(w) == 1
+    @test lastindex(w) == nsrc
+    @test ndims(w) == 2
+
+    copy!(w2, w)
+    @test isequal(w2.weights, w.weights)
+    @test isequal(w2.nsrc, w.nsrc)
+    @test firstindex(w) == 1
+    @test lastindex(w) == nsrc
+    @test ndims(w) == 2
 
     # vcat
     w_vcat = [w; w]
@@ -82,7 +118,6 @@ ftol = 1f-6
     @test isapprox(u, u .* 1; rtol=ftol)
     @test isapprox(a .* (u + v), a .* u + a .* v; rtol=1f-5)
     @test isapprox((a + b) .* v, a .* v + b.* v; rtol=1f-5)
-
 
     # broadcast multiplication
     u = judiWeights(randn(Float32, weight_size_x, weight_size_y); nsrc=nsrc)

--- a/test/test_linear_algebra.jl
+++ b/test/test_linear_algebra.jl
@@ -6,7 +6,7 @@ using JUDI.TimeModeling, Test, LinearAlgebra, Printf
 parsed_args = parse_commandline()
 
 nlayer = parsed_args["nlayer"]
-tti = parsed_args["fs"]
+tti = parsed_args["tti"]
 fs =  parsed_args["fs"]
 
 @testset "Arithmetic test with $(nlayer) layers and tti $(tti) and freesurface $(fs)" begin

--- a/test/test_linearity.jl
+++ b/test/test_linearity.jl
@@ -11,7 +11,7 @@ parsed_args = parse_commandline()
 
 
 nlayer = parsed_args["nlayer"]
-tti = parsed_args["fs"]
+tti = parsed_args["tti"]
 fs =  parsed_args["fs"]
 
 ### Model


### PR DESCRIPTION
# Main update

New `lsrtm_objective(model0, q, data, dm; options=Options())` that implements the objective function and gradient for

```math
.5 || J(m0) dm - data||^2
``` 

this function accepts the `nlind` option as `lsrtm_objective(model0, q, data, dm; options=Options(), nlind=Flase)` that defaults to False that implements

```math
.5 || J(m0) dm - (data - F(m0)*q)||^2
``` 


Uses the same way as `fwi_objective` and added `test_gradient_lsrtm` as well as example in `modeling_basic_2d.jl`

# Minor changes

- Model parameters are now filtered and reduced to a number if constant to avoid unnecessary array
- Born only compute the nonlinear background wavefield is dm is zero
- Removed nightly from CI, not maintainable
- Fix DFT args for `fwi_objective`
- Cleanup `runtest` 