### PR TITLE
Overload cumsum and diff functions for judiVector

### DIFF
--- a/src/TimeModeling/TimeModeling.jl
+++ b/src/TimeModeling/TimeModeling.jl
@@ -14,6 +14,7 @@ import Base.getindex, Base.setindex!, Base.firstindex, Base.lastindex, Base.axes
 import Base.similar, Base.isapprox, Base.isequal, Base.broadcast!, Base.materialize!, Base.materialize
 import Base.eltype, Base.length, Base.size, Base.iterate, Base.show, Base.display, Base.showarg
 import Base.promote_shape
+import Base.cumsum, Base.diff
 
 import LinearAlgebra.transpose, LinearAlgebra.conj, LinearAlgebra.vcat, LinearAlgebra.adjoint
 import LinearAlgebra.vec, LinearAlgebra.dot, LinearAlgebra.norm, LinearAlgebra.abs

--- a/src/TimeModeling/judiVector.jl
+++ b/src/TimeModeling/judiVector.jl
@@ -712,7 +712,7 @@ iterate(S::judiVector, state::Integer=1) = state > S.nsrc ? nothing : (S.data[st
 # Integration/differentiation of shot records
 
 function cumsum(x::judiVector;dims=1)
-    dims == 1 || dims == 2 || throw(judiVectorException("dims is out of range, please double check your dims argument"))
+    dims == 1 || dims == 2 || throw(judiVectorException("Dimension $(dims) is out of range for a 2D array"))
     y = deepcopy(x)
     for i = 1:x.nsrc
         cumsum!(y.data[i], x.data[i], dims=dims)
@@ -722,7 +722,7 @@ end
 
 function diff(x::judiVector;dims=1)
     # note that this is not the same as default diff in julia, the first entry stays in the diff result
-    dims == 1 || dims == 2 || throw(judiVectorException("dims is out of range, please double check your dims argument"))
+    dims == 1 || dims == 2 || throw(judiVectorException("Dimension $(dims) is out of range for a 2D array"))
     y = deepcopy(x)
     for i = 1:x.nsrc
         y.data[i][2:end,:] = diff(x.data[i],dims=dims)

--- a/src/TimeModeling/judiVector.jl
+++ b/src/TimeModeling/judiVector.jl
@@ -709,6 +709,30 @@ iterate(S::judiVector, state::Integer=1) = state > S.nsrc ? nothing : (S.data[st
 
 ####################################################################################################
 
+# Integration/differentiation of shot records
+
+function cumsum(x::judiVector;dims=1)
+    dims == 1 || @warn("Integration over receivers might not make sense, please double check your dims argument")
+    y = deepcopy(x)
+    for i = 1:x.nsrc
+        y.data[i] = cumsum(x.data[i],dims=dims)
+    end
+    return y
+end
+
+function diff(x::judiVector;dims=1)
+    # note that this is not the same as default diff in julia, the first entry stays in the diff result
+    dims == 1 || @warn("Differentiation over receivers might not make sense, please double check your dims argument")
+    y = deepcopy(x)
+    for i = 1:x.nsrc
+        y.data[i][1,:]= x.data[i][1,:]
+        y.data[i][2:end,:] = diff(x.data[i],dims=dims)
+    end
+    return y
+end
+
+####################################################################################################
+
 BroadcastStyle(::Type{judiVector}) = Base.Broadcast.DefaultArrayStyle{1}()
 
 ndims(::Type{judiVector{Float32}}) = 1

--- a/src/TimeModeling/judiVector.jl
+++ b/src/TimeModeling/judiVector.jl
@@ -712,20 +712,19 @@ iterate(S::judiVector, state::Integer=1) = state > S.nsrc ? nothing : (S.data[st
 # Integration/differentiation of shot records
 
 function cumsum(x::judiVector;dims=1)
-    dims == 1 || @warn("Integration over receivers might not make sense, please double check your dims argument")
+    dims == 1 || dims == 2 || throw(judiVectorException("dims is out of range, please double check your dims argument"))
     y = deepcopy(x)
     for i = 1:x.nsrc
-        y.data[i] = cumsum(x.data[i],dims=dims)
+        cumsum!(y.data[i], x.data[i], dims=dims)
     end
     return y
 end
 
 function diff(x::judiVector;dims=1)
     # note that this is not the same as default diff in julia, the first entry stays in the diff result
-    dims == 1 || @warn("Differentiation over receivers might not make sense, please double check your dims argument")
+    dims == 1 || dims == 2 || throw(judiVectorException("dims is out of range, please double check your dims argument"))
     y = deepcopy(x)
     for i = 1:x.nsrc
-        y.data[i][1,:]= x.data[i][1,:]
         y.data[i][2:end,:] = diff(x.data[i],dims=dims)
     end
     return y

--- a/test/test_judiVector.jl
+++ b/test/test_judiVector.jl
@@ -357,4 +357,18 @@ ftol = 1e-6
     @test isapprox(tr.geometry.zloc[1][12:end], range(30., -30., length=11); atol=1f-14, rtol=1f-14)
     @test isapprox(tr.geometry.xloc[1][12:end], -10f0*ones(11); atol=1f-14, rtol=1f-14)
     @test isapprox(tr.geometry.xloc[1][1:11], zeros(11); atol=1f-14, rtol=1f-14)
+
+    # Test integral & derivative
+
+    d_orig = judiVector(Geometry(0f0, 0f0, 0f0; dt=2, t=1000), randn(251))
+    d_cumsum = cumsum(d_orig)
+    for i = 1:d_orig.nsrc
+        @test isapprox(cumsum(d_orig.data[i],dims=1), d_cumsum.data[i])
+    end
+    d_diff = diff(d_orig)
+    for i = 1:d_orig.nsrc
+        @test isapprox(d_orig.data[i][1,:], d_diff.data[i][1,:])
+        @test isapprox(d_diff.data[i][2:end,:], diff(d_orig.data[i],dims=1))
+    end
+
 end

--- a/test/test_judiVector.jl
+++ b/test/test_judiVector.jl
@@ -359,16 +359,16 @@ ftol = 1e-6
     @test isapprox(tr.geometry.xloc[1][1:11], zeros(11); atol=1f-14, rtol=1f-14)
 
     # Test integral & derivative
-
-    d_orig = judiVector(Geometry(0f0, 0f0, 0f0; dt=2, t=1000), randn(251))
+    refarray = randn(Float32,251)
+    d_orig = judiVector(Geometry(0f0, 0f0, 0f0; dt=2, t=1000), refarray)
     d_cumsum = cumsum(d_orig)
     for i = 1:d_orig.nsrc
-        @test isapprox(cumsum(d_orig.data[i],dims=1), d_cumsum.data[i])
+        @test isapprox(cumsum(refarray,dims=1), d_cumsum.data[i])
     end
     d_diff = diff(d_orig)
     for i = 1:d_orig.nsrc
-        @test isapprox(d_orig.data[i][1,:], d_diff.data[i][1,:])
-        @test isapprox(d_diff.data[i][2:end,:], diff(d_orig.data[i],dims=1))
+        @test isapprox(refarray[1,:], d_diff.data[i][1,:])
+        @test isapprox(d_diff.data[i][2:end,:], diff(refarray,dims=1))
     end
 
 end


### PR DESCRIPTION
I overloaded cumsum and diff functions for judiVector and added associated tests with them. These functions work as integral or derivative along each receiver trace. Also notice that the `diff` operator does not work the same as the default one in Julia. I manually remained the first entry in each receiver trace, so that the shape of judiVector (geometry) stays the same.

This is useful not only for an overload of Base functions, but also for defining left seismic preconditioners working on derivative/integrals of shot records.