### PR TITLE
Extend gradient already outputs physical parameters

### DIFF
--- a/src/TimeModeling/time_modeling_serial.jl
+++ b/src/TimeModeling/time_modeling_serial.jl
@@ -52,11 +52,7 @@ function time_modeling(model_full::Model, srcGeometry, srcData, recGeometry, rec
 
     # Extend gradient back to original model size
     if op=='J' && mode==-1 && options.limit_m==true
-        if options.return_array == true
-            argout = extend_gradient(model_full, model, argout)
-        else
-            argout = PhysicalParameter(extend_gradient(model_full, model, argout), model.d, model.o)
-        end
+        argout = extend_gradient(model_full, model, argout)
     end
 
     return argout


### PR DESCRIPTION
The problem is at here https://github.com/slimgroup/JUDI.jl/blob/64c2a7d0d988eca4ff541f6b09b85e207c4b26f8/src/TimeModeling/time_modeling_serial.jl#L58

`extend_gradient` already outputs a physical parameter