### PR TITLE
Backward compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JUDI"
 uuid = "f3b833dc-6b2e-5b9c-b940-873ed6319979"
 authors = ["Philipp Witte, Mathias Louboutin"]
-version = "2.6.3"
+version = "2.6.4"
 
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
@@ -15,19 +15,20 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SegyIO = "157a0f19-4d44-4de5-a0d0-07e2f0ac4dfa"
 
 [compat]
-julia = "1"
-JOLI = "0.7"
-FFTW = "1"
-PyCall = "1.18, 1.90, 1.91, 1.62"
-Dierckx = "0.4, 0.5"
 DSP = "0.6, 0.7"
+Dierckx = "0.4, 0.5"
+FFTW = "1"
+JOLI = "0.7"
+PyCall = "1.18, 1.90, 1.91, 1.62"
 Reexport = "0.2, 1"
 SegyIO = "0.7"
+julia = "1"
 
 [extras]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 
 [targets]
-test = ["Test", "ArgParse", "Printf"]
+test = ["Test", "ArgParse", "Printf", "JLD2"]

--- a/src/JUDI.jl
+++ b/src/JUDI.jl
@@ -55,8 +55,17 @@ function __init__()
     copy!(ac, pyimport("interface"))
 end
 
-
 # JUDI time modeling
 include("TimeModeling/TimeModeling.jl")
+
+module TimeModeling
+    using ..JUDI
+    # Define backward compatible types so that old JLD files load properly
+    # Old JLD file expected to be arrays, SeisCon are expected to be read and built
+    # from SEGY files
+    const judiVector{T} = JUDI.judiVector{T, Matrix{T}} where T
+    const GeometryIC = JUDI.GeometryIC{Float32}
+    const GeometryOOC = JUDI.GeometryOOC{Float32}
+end
 
 end

--- a/src/TimeModeling/Types/GeometryStructure.jl
+++ b/src/TimeModeling/Types/GeometryStructure.jl
@@ -7,7 +7,8 @@ export Geometry, compareGeometry, GeometryIC, GeometryOOC, get_nsrc, n_samples
 
 abstract type Geometry end
 
-const CoordT = Union{Array{T, 1}, Array{Array{T, 1}, 1}} where T
+const CoordT = Union{Array{T, 1}, Array{Array{T, 1}, 1}} where T<:Number
+(::Type{CoordT})(x::Vector{Any}) = rebuild_maybe_jld(x)
 
 # In-core geometry structure for seismic header information
 mutable struct GeometryIC{T} <: Geometry
@@ -153,7 +154,6 @@ function Geometry(xloc::Array{T, 1}, yloc::CoordT, zloc::Array{T, 1}; dt=[], t=[
     tCell = [T(t) for j=1:nsrc]
     return GeometryIC{T}(xlocCell, ylocCell, zlocCell, dtCell, ntCell, tCell)
 end
-
 
 ################################################ Constructors from SEGY data  ####################################################
 

--- a/src/TimeModeling/Types/typeutils.jl
+++ b/src/TimeModeling/Types/typeutils.jl
@@ -131,3 +131,17 @@ end
 function vcat(a::Array{T, 1}) where T<:Union{judiVector, judiWeights, judiWavefield}
     return vcat(a...)
 end
+
+
+##### Rebuild bad vector
+
+function rebuild_maybe_jld(x::Vector{Any})
+    try
+        return tof32(x)
+    catch e
+        if hasproperty(x[1], :offset)
+            return [Float32.(StepRangeLen(xi.ref, xi.step, xi.len, xi.offset)) for xi in x]
+        end
+        return x
+    end
+end

--- a/src/TimeModeling/Utils/auxiliaryFunctions.jl
+++ b/src/TimeModeling/Utils/auxiliaryFunctions.jl
@@ -485,6 +485,7 @@ function setup_3D_grid(xrec::AbstractVector{T},yrec::AbstractVector{T}, zrec::T)
 end
 
 setup_3D_grid(xrec, yrec, zrec) = setup_3D_grid(tof32(xrec), tof32(yrec), tof32(zrec))
+
 function setup_3D_grid(xrec::Vector{Any}, yrec::Vector{Any}, zrec::Vector{Any})
     xrec, yrec, zrec = convert(Vector{typeof(xrec[1])},xrec), convert(Vector{typeof(yrec[1])}, yrec), convert(Vector{typeof(zrec[1])},zrec)
     setup_3D_grid(xrec, yrec, zrec)

--- a/test/test_issues.jl
+++ b/test/test_issues.jl
@@ -1,4 +1,4 @@
-
+using JLD2
 
 @testset "Test issue #83" begin
     nxrec = 120
@@ -17,4 +17,17 @@
         @test all(y3d[s:e] .== yrec[k])
     end
     @test all(z3d .== zrec)
+end
+
+@testset "Test backward comp issue" begin
+    datapath = joinpath(dirname(pathof(JUDI)))*"/../data/"
+
+    # Load file with old judiVector type and julia <1.7 StepRangeLen
+    @load "$(datapath)backward_comp.jld" dat model_true
+
+    @test typeof(dat) == judiVector{Float32, Matrix{Float32}}
+    @test typeof(dat.geometry) == GeometryIC{Float32}
+    @test typeof(dat.geometry.xloc) == Vector{Vector{Float32}}
+    @test typeof(model_true) == Model
+    @test typeof(model_true.m) == PhysicalParameter{Float32}
 end


### PR DESCRIPTION
Add some backward compatibility type so that old JLD files are loaded safely and converted to correct new types.

@yzhang3198 should fix your issue loading older JLD files.