### PR TITLE
Fix src geometry by convertToCell

### DIFF
--- a/test/test_geometry.jl
+++ b/test/test_geometry.jl
@@ -47,9 +47,9 @@ datapath = joinpath(dirname(pathof(JUDI)))*"/../data/"
 
     @test isequal(typeof(src_geometry), GeometryIC{Float32})
     @test isequal(typeof(rec_geometry), GeometryIC{Float32})
-    @test isequal(get_header(block, "SourceSurfaceElevation")[1], src_geometry.zloc[1])
+    @test isequal(get_header(block, "SourceSurfaceElevation")[1], src_geometry.zloc[1][1])
     @test isequal(get_header(block, "RecGroupElevation")[1], rec_geometry.zloc[1][1])
-    @test isequal(get_header(block, "SourceX")[1], src_geometry.xloc[1])
+    @test isequal(get_header(block, "SourceX")[1], src_geometry.xloc[1][1])
     @test isequal(get_header(block, "GroupX")[1], rec_geometry.xloc[1][1])
 
     # Set up geometry summary from out-of-core data container
@@ -88,9 +88,9 @@ datapath = joinpath(dirname(pathof(JUDI)))*"/../data/"
 
     @test isequal(typeof(src_geometry_ic), GeometryIC{Float32})
     @test isequal(typeof(rec_geometry_ic), GeometryIC{Float32})
-    @test isequal(get_header(block, "SourceSurfaceElevation")[1], src_geometry_ic.zloc[1])
+    @test isequal(get_header(block, "SourceSurfaceElevation")[1], src_geometry_ic.zloc[1][1])
     @test isequal(get_header(block, "RecGroupElevation")[1], rec_geometry_ic.zloc[1][1])
-    @test isequal(get_header(block, "SourceX")[1], src_geometry_ic.xloc[1])
+    @test isequal(get_header(block, "SourceX")[1], src_geometry_ic.xloc[1][1])
     @test isequal(get_header(block, "GroupX")[1], rec_geometry_ic.xloc[1][1])
 
     # Subsample in-core geometry structure


### PR DESCRIPTION
fix #93 

This would really be the minimal change, i.e. if. key is source, then do `convertToCell`. A couple of test cases need to be adjusted according to the change.
Another change I made it to make `Geometry` struct typed. This has nothing to do with the problem itself, but why not : )