### PR TITLE
Added parameter to not use the Julia worker pool

### DIFF
--- a/src/JUDI.jl
+++ b/src/JUDI.jl
@@ -6,7 +6,7 @@
 __precompile__()
 module JUDI
 
-export JUDIPATH, set_verbosity, ftp_data
+export JUDIPATH, set_verbosity, ftp_data, set_serial, set_parallel
 JUDIPATH = dirname(pathof(JUDI))
 
 # Dependencies
@@ -85,7 +85,15 @@ function rlock_pycall(meth, ::Type{T}, args...; kw...) where T
 end
 
 # Constants
+_serial = false
+set_serial(x::Bool) = begin global _serial = x; end
+set_serial() = begin global _serial = true; end
+set_parallel() = begin global _serial = false; end
+
 function _worker_pool()
+    if _serial
+        return nothing
+    end
     p = default_worker_pool()
     pool = length(p) < 2 ? nothing : p
     return pool

--- a/src/JUDI.jl
+++ b/src/JUDI.jl
@@ -86,6 +86,7 @@ end
 
 # Constants
 _serial = false
+get_serial() = _serial
 set_serial(x::Bool) = begin global _serial = x; end
 set_serial() = begin global _serial = true; end
 set_parallel() = begin global _serial = false; end

--- a/src/JUDI.jl
+++ b/src/JUDI.jl
@@ -6,7 +6,7 @@
 __precompile__()
 module JUDI
 
-export JUDIPATH, set_verbosity, ftp_data, set_serial, set_parallel
+export JUDIPATH, set_verbosity, ftp_data, get_serial, set_serial, set_parallel
 JUDIPATH = dirname(pathof(JUDI))
 
 # Dependencies

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -160,9 +160,23 @@ function test_ftp()
     rm("$(JUDI.JUDI_DATA)/overthrust_model_2D.h5")
 end
 
+function test_serial()
+    @test !get_serial()
+
+    set_serial()
+    @test get_serial()
+
+    set_parallel()
+    @test !get_serial()
+
+    set_serial(true)
+    @test get_serial()
+end
+
 @testset "Test basic utilities" begin
     @timeit TIMEROUTPUT "Basic setup utilities" begin
         test_ftp()
+        test_serial()
         setup_3d()
         for ndim=[2, 3]
             test_padding(ndim)
@@ -193,7 +207,7 @@ end
                 modelPy = devito_model(model, Options(dt_comp=.5f0))
                 @test modelPy.critical_dt == .5f0
 
-                # Verify nt
+                # Verify nt
                 srcGeometry = example_src_geometry()
                 recGeometry = example_rec_geometry(cut=true)
                 nt1 = get_computational_nt(srcGeometry, recGeometry, model)

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -171,6 +171,9 @@ function test_serial()
 
     set_serial(true)
     @test get_serial()
+
+    set_serial(false)
+    @test !get_serial()
 end
 
 @testset "Test basic utilities" begin


### PR DESCRIPTION
By default, JUDI uses all workers in the current pool. This MR allows the user to specify to run serially even when there is a worker pool.