### PR TITLE
Don't extend implicit `eval` method

### DIFF
--- a/ext/JLD2JUDIExt.jl
+++ b/ext/JLD2JUDIExt.jl
@@ -10,7 +10,7 @@ JUDI.Geometry(x::JLD2.ReconstructedMutable{N, FN, NT}) where {N, FN, NT} = Geome
 function JUDI.tof32(x::JLD2.ReconstructedStatic{N, FN, NT}) where {N, FN, NT}
     # Drop "typed" signature
     reconstructT = Symbol(split(string(N), "{")[1])
-    return JUDI.tof32(eval(reconstructT)([getproperty(x, f) for f in FN]...))
+    return JUDI.tof32(getproperty(@__MODULE__, reconstructT)([getproperty(x, f) for f in FN]...))
 end
 
 end

--- a/src/TimeModeling/LinearOperators/lazy.jl
+++ b/src/TimeModeling/LinearOperators/lazy.jl
@@ -215,4 +215,4 @@ _as_src(::judiNoopOperator, ::AbstractModel, q::judiMultiSourceVector) = q
 
 ############################################################################################################################
 ###### Evaluate lazy operation
-eval(rhs::judiRHS) = rhs.d
+eval_lazy(rhs::judiRHS) = rhs.d

--- a/src/TimeModeling/Modeling/python_interface.jl
+++ b/src/TimeModeling/Modeling/python_interface.jl
@@ -35,9 +35,10 @@ function wrapcall_weights(func, args...;kw...)
     return out
 end
 
-function wrapcall_wf(func, args...;kw...)
-    rtype = _outtype(get(kw, :illum, nothing), 1, Array{Float32})
-    out = rlock_pycall(func, rtype, args...;kw...)
+function wrapcall_wf(func, modelPy, args...;kw...)
+    ndim = modelPy.dim + 1 # Add time dimension
+    rtype = _outtype(get(kw, :illum, nothing), 1, Array{Float32, ndim})
+    out = rlock_pycall(func, rtype, modelPy, args...;kw...)
     return out
 end
 

--- a/src/TimeModeling/Types/GeometryStructure.jl
+++ b/src/TimeModeling/Types/GeometryStructure.jl
@@ -39,9 +39,9 @@ function getproperty(G::Geometry, s::Symbol)
     end
     # Legacy dt/nt/t
     if s in [:dt, :t, :nt, :t0]
-        return eval(Symbol("get_$(s)"))(G)
+        return getproperty(@__MODULE__, Symbol("get_$(s)"))(G)
     end
-    
+
     return getfield(G, s)
 end
 

--- a/src/TimeModeling/Types/lazy_msv.jl
+++ b/src/TimeModeling/Types/lazy_msv.jl
@@ -34,9 +34,9 @@ end
 getindex(la::LazyAdd{D}, i::RangeOrVec) where D = LazyAdd{D}(length(i), la.A[i], la.B[i], la.sign)
 
 
-function eval(ls::LazyAdd{D}) where D
-    aloc = eval(ls.A)
-    bloc = eval(ls.B)
+function eval_lazy(ls::LazyAdd{D}) where D
+    aloc = eval_lazy(ls.A)
+    bloc = eval_lazy(ls.B)
     ga = aloc.geometry
     gb = bloc.geometry
     @assert (ga.nt == gb.nt && ga.dt == gb.dt && ga.t == gb.t)
@@ -49,7 +49,7 @@ function eval(ls::LazyAdd{D}) where D
 end
 
 function make_src(ls::LazyAdd{D}) where D
-    q = eval(ls)
+    q = eval_lazy(ls)
     return q.geometry[1], q.data[1]
 end
 


### PR DESCRIPTION
The `eval` and `include` generic functions are implicitly provided by `module` for every new julia module. Currently it is possible to extend these (somewhat by accident), but this might change in https://github.com/JuliaLang/julia/pull/55949.

To avoid that causing issues, this renames the `eval` method in this package to `eval_lazy` to avoid accidentally extending the builtin. If desireed, you could instead use a baremodule to avoid creating the implicit functions (see e.g. https://github.com/phelipe/Fuzzy.jl/pull/21).

While I'm here, also strength-reduce the (builtin) `eval` method to `getproperty` instead as applicable. This is not required, but simply a best practice to avoid requiring the full semantics of `eval` (which include arbitrary code execution) when it is not needed.

I was unable to test this locally due to some python dependency errors, so please take a careful look to make sure I got this right.